### PR TITLE
[Fix] renderScrollComponent should spread props on ScrollView

### DIFF
--- a/lib/reversed-flat-list.js
+++ b/lib/reversed-flat-list.js
@@ -35,7 +35,7 @@ export default class ReversedList extends React.Component {
 
   // then backing scrollview is flipped to reverse the list
   renderScrollComponent = ({ style, refreshing, ...props }) => (
-    <ScrollView style={[style, styles.flip]} />
+    <ScrollView style={[style, styles.flip]} {...props} />
   );
 
   // each row is flipped back to normal position


### PR DESCRIPTION
Currently, the `renderScrollComponent` does not spread props on the `ScrollView`. This means you can't pass props such as `keyboardDismissMode` to ReversedFlatList.

This is the default behavior of `VirtualizedList` (which `FlatList` uses under the hood) https://github.com/facebook/react-native/blob/a2b0ee0fc3423be94021d56c8f8141cb9b587836/Libraries/Lists/VirtualizedList.js#L741
